### PR TITLE
test(web): fix mock hoisting for Profile API

### DIFF
--- a/apps/web/src/app/api/profile/__tests__/route.test.ts
+++ b/apps/web/src/app/api/profile/__tests__/route.test.ts
@@ -1,23 +1,26 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
 
-// --- Mocks ---
-const setMock = vi.fn();
-const getMock = vi.fn();
-const docMock = vi.fn(() => ({ set: setMock, get: getMock }));
-const collectionMock = vi.fn(() => ({ doc: docMock }));
+/**
+ * Hoisted mocks for db-admin and next-auth.
+ * We import route handlers AFTER mocks to avoid hoisting issues.
+ */
 
-vi.mock('@/lib/firebase/db-admin', () => ({
-  db: {
-    collection: collectionMock,
-  },
-}));
+vi.mock("@/lib/firebase/db-admin", () => {
+  const setMock = vi.fn();
+  const getMock = vi.fn();
+  const docMock = vi.fn(() => ({ set: setMock, get: getMock }));
+  const collectionMock = vi.fn(() => ({ doc: docMock }));
+  return { db: { collection: collectionMock } };
+});
 
 vi.mock("next-auth", () => ({
   getServerSession: vi.fn(),
 }));
-// --- End Mocks ---
 
-import type { NextRequest } from "next/server";
+// Lazy imports after mocks are set
+const { db } = await import("@/lib/firebase/db-admin");
+const { getServerSession } = await import("next-auth");
 
 function makeReq(url: string, method: "GET" | "PUT", body?: any): NextRequest {
   const u = new URL(url);
@@ -31,49 +34,52 @@ function makeReq(url: string, method: "GET" | "PUT", body?: any): NextRequest {
   } as unknown as NextRequest;
 }
 
-const { getServerSession } = await import("next-auth");
+// convenience access to inner mock fns for assertions
+const getCollectionMock = (db.collection as unknown as jest.Mock | vi.Mock);
+const getDocMock = getCollectionMock().doc as any;
+const getSetMock = getDocMock().set as any;
+const getGetMock = getDocMock().get as any;
 
 describe("Profile API", () => {
-  let GET: any;
-  let PUT: any;
+  // Import route handlers after resetting modules to ensure mocks apply
+  let GET: typeof import("../route").GET;
+  let PUT: typeof import("../route").PUT;
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.resetModules();
     ({ GET, PUT } = await import("../route"));
   });
 
   it("GET denies when not authenticated", async () => {
     (getServerSession as any).mockResolvedValue(null);
-    const res: any = await GET(makeReq("http://localhost/api/profile", "GET"));
+    const res = await GET(makeReq("http://localhost/api/profile", "GET"));
     expect(res.status).toBe(401);
   });
 
   it("GET returns default shell when no doc", async () => {
     (getServerSession as any).mockResolvedValue({ user: { id: "u1", name: "Jane" } });
-    getMock.mockResolvedValueOnce({ exists: false });
-    const res: any = await GET(makeReq("http://localhost/api/profile", "GET"));
+    getGetMock.mockResolvedValueOnce({ exists: false });
+    const res = await GET(makeReq("http://localhost/api/profile", "GET"));
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json).toMatchObject({ id: "u1", role: "patient", displayName: "Jane" });
-    expect(collectionMock).toHaveBeenCalledWith("users");
+    expect(getCollectionMock).toHaveBeenCalledWith("users");
+    expect(getDocMock).toHaveBeenCalledWith("u1");
   });
 
   it("PUT prevents self-elevation to admin", async () => {
     (getServerSession as any).mockResolvedValue({ user: { id: "u1", role: "patient" } });
-    const res: any = await PUT(
-      makeReq("http://localhost/api/profile", "PUT", { role: "admin" })
-    );
+    const res = await PUT(makeReq("http://localhost/api/profile", "PUT", { role: "admin" }));
     expect(res.status).toBe(403);
   });
 
-  it("PUT accepts patient->nurse", async () => {
+  it("PUT merges allowed updates (e.g. patient -> nurse)", async () => {
     (getServerSession as any).mockResolvedValue({ user: { id: "u1", role: "patient" } });
-    const res: any = await PUT(
-      makeReq("http://localhost/api/profile", "PUT", { role: "nurse", displayName: "J" })
-    );
+    const res = await PUT(makeReq("http://localhost/api/profile", "PUT", { role: "nurse", displayName: "J" }));
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json).toMatchObject({ id: "u1", role: "nurse", displayName: "J" });
-    expect(setMock).toHaveBeenCalledWith({ role: "nurse", displayName: "J" }, { merge: true });
+    expect(getSetMock).toHaveBeenCalledWith({ role: "nurse", displayName: "J" }, { merge: true });
   });
 });


### PR DESCRIPTION
Hoist '@/lib/firebase/db-admin' mock and import handlers after mocks. All unit tests green.